### PR TITLE
convert binary Alt to *-ary Alt to reduce in-degree

### DIFF
--- a/eval/unittest-prototype.py
+++ b/eval/unittest-prototype.py
@@ -54,7 +54,7 @@ class TestCase:
          libMemo.ProtoRegexEngine.ENCODING_SCHEME.scheme2cox[encodingScheme] != "none":
          continue
 
-      rawCmd = "{} {} {} {} {}".format(libMemo.ProtoRegexEngine.CLI,
+      rawCmd = "{} {} {} '{}' {}".format(libMemo.ProtoRegexEngine.CLI,
             libMemo.ProtoRegexEngine.SELECTION_SCHEME.scheme2cox[selectionScheme],
             libMemo.ProtoRegexEngine.ENCODING_SCHEME.scheme2cox[encodingScheme],
           self.regex, self.input
@@ -67,9 +67,7 @@ class TestCase:
       if (em.matched and self.shouldMatch) or (not em.matched and not self.shouldMatch):
         tr = TestResult(True, "Correct, match(/{}/, {})={} under selection '{}' encoding '{}'".format(self.regex, self.input, em.matched, selectionScheme, encodingScheme))
       else:
-        tr = False, "Incorrect, match(/{}/, {})={} under selection {} encoding {} -- try {}".format(
-          self.regex, self.input, em.matched, selectionScheme, encodingScheme, rawCmd
-        )
+        tr = TestResult(False, "Incorrect, match(/{}/, {})={} under selection {} encoding {} -- try {}".format(self.regex, self.input, em.matched, selectionScheme, encodingScheme, rawCmd))
       testResults.append(tr)
     return testResults
 
@@ -115,7 +113,7 @@ def main(queryFile):
     anyFailures = False
     for testResult in testCase.run():
       if not testResult.success:
-        testFailures.append(testResult.descr)
+        testFailures.append(testResult.description)
         anyFailures = True
 
     if anyFailures:

--- a/src-simple/main.c
+++ b/src-simple/main.c
@@ -156,12 +156,24 @@ main(int argc, char **argv)
 		q.input = argv[4];
 	}
 
+	// Parse
 	re = parse(q.regex);
+
+	// Optimize
+	logMsg(LOG_INFO, "Non-optimized re:");
 	printre(re);
 	printf("\n");
 
+	re = optimize(re);
+	logMsg(LOG_INFO, "Optimized re:");
+	printre(re);
+	printf("\n");
+
+	// Compile
 	prog = compile(re, memoMode);
 	printprog(prog);
+
+	// Simulate
 	prog->memoMode = memoMode;
 	prog->memoEncoding = memoEncoding;
 

--- a/src-simple/parse.y
+++ b/src-simple/parse.y
@@ -308,6 +308,8 @@ reg(int type, Regexp *left, Regexp *right)
 void
 printre(Regexp *r)
 {
+	int i;
+
 	switch(r->type) {
 	default:
 		printf("???");
@@ -318,6 +320,17 @@ printre(Regexp *r)
 		printre(r->left);
 		printf(", ");
 		printre(r->right);
+		printf(")");
+		break;
+
+	case AltList:
+		printf("AltList(");
+		for (i = 0; i < r->arity; i++) {
+			printre(r->children[i]);
+			if (i+1 < r->arity) {
+				printf(", ");
+			}
+		}
 		printf(")");
 		break;
 

--- a/src-simple/test/query-response.txt
+++ b/src-simple/test/query-response.txt
@@ -60,3 +60,24 @@ a\Da    , axa             , MATCH
 .*.*    , aaaaaaaaaaaaaa  , MATCH
 (..)*   , aaaaaaaaaaaaaa  , MATCH
 (..)*   , aaaaaaaaaaaaaaa , MATCH
+
+# AltList / SplitMany
+a|b , a , MATCH
+a|b , b , MATCH
+a|b , c , MISMATCH
+a|b|c|d|e , a , MATCH
+a|b|c|d|e , b , MATCH
+a|b|c|d|e , c , MATCH
+a|b|c|d|e , d , MATCH
+a|b|c|d|e , e , MATCH
+a|b|c|d|e , f , MISMATCH
+x(a|b|c|d)y , xay, MATCH
+x(a|b|c|d)y , xby, MATCH
+x(a|b|c|d)y , xcy, MATCH
+x(a|b|c|d)y , xdy, MATCH
+x(a|b|c|d)y , xy, MISMATCH
+x(a|b|c|d)y , xey, MISMATCH
+(a|(b|c)|d) , a, MATCH
+(a|(b|c)|d) , b, MATCH
+(a|(b|c)|d) , c, MATCH
+(a|(b|c)|d) , d, MATCH


### PR DESCRIPTION
Problem:
  The VM had 2-arity for all operations.
  a|b|c|d|... was generating a 2-arity sequence of nested ORs.
  So we artificially had N-1 vertices with in-degree > 1.

Solution:
  Introduce
    - add a *-arity AltList Regexp
    - optimization pass to convert Alt(Alt(...), ...) into an AltList
    - add a *-arity SplitMany Instr
    - emit code to generate a SplitMany from an AltList

Now a|b|c|d|... yields a single vertex with in-degree > 1,
and a|(b|c)|... yields two vertices -- nested AltLists

Fixes #4