### PR TITLE
memoization for backrefs

### DIFF
--- a/eval/analyze_phi_measurements.py
+++ b/eval/analyze_phi_measurements.py
@@ -135,10 +135,10 @@ dfRatios = pd.DataFrame(data=rows, columns=['Regex type', 'Measure', 'Value'])
 
 pd.set_option('display.max_columns', 30)
 print("\n*******\n\n  Summary of raw values:\n\n")
-print(dfRaw.groupby(['Regex type', 'Measure']).describe())
+print(dfRaw.groupby(['Regex type', 'Measure']).describe(percentiles=[0.01, 0.05, 0.1, .25, .5, .75, 0.9, 0.95, 0.99]))
 
 print("\n*******\n\n  Summary of ratios:\n\n")
-print(dfRatios.groupby(['Regex type', 'Measure']).describe())
+print(dfRatios.groupby(['Regex type', 'Measure']).describe(percentiles=[0.01, 0.05, 0.1, .25, .5, .75, 0.9, 0.95, 0.99]))
 
 """## Plot"""
 

--- a/src-simple/main.c
+++ b/src-simple/main.c
@@ -141,13 +141,15 @@ main(int argc, char **argv)
 	Query q;
 	Regexp *re;
 	Prog *prog;
-	char *sub[MAXSUB];
+	char *sub[MAXSUB]; /* Start and end pointers for each CG */
 
 	if(argc < 4)
 		usage();
 	
 	memoMode = getMemoMode(argv[1]);
 	memoEncoding = getEncoding(argv[2]);
+	if (memoMode == MEMO_NONE)
+		memoEncoding = ENCODING_NONE;
 
 	if (strcmp(argv[3], "-f") == 0) {
 		q = loadQuery(argv[4]);

--- a/src-simple/pike.c
+++ b/src-simple/pike.c
@@ -70,7 +70,7 @@ pikevm(Prog *prog, char *input, char **subp, int nsubp)
 	matched = nil;	
 	for(i=0; i<nsubp; i++)
 		subp[i] = nil;
-	sub = newsub(nsubp);
+	sub = newsub(nsubp, input);
 	for(i=0; i<nsubp; i++)
 		sub->sub[i] = nil;
 

--- a/src-simple/regexp.h
+++ b/src-simple/regexp.h
@@ -173,19 +173,24 @@ struct Sub
 {
 	int ref;
 	int nsub;
-	char *sub[MAXSUB];
+	char *start; /* Easy way to calculate w[i] vs. char * */
+	char *sub[MAXSUB]; /* Two slots for each CG, \0 (whole string) - \9 */
 };
 
-Sub *newsub(int n);
+Sub *newsub(int n, char *start);
 Sub *incref(Sub*);
 Sub *copy(Sub*);
 Sub *update(Sub*, int, char*);
 void decref(Sub*);
+int isgroupset(Sub*, int);
 
 struct SearchState
 {
 	int stateNum;
 	int stringIndex;
+	/* Used for backrefs */
+	int cgStarts[MAXSUB/2];
+	int cgEnds[MAXSUB/2];
 };
 
 struct SearchStateTable
@@ -194,21 +199,23 @@ struct SearchStateTable
 	UT_hash_handle hh; /* Makes this structure hashable */
 };
 
+/* Declare here so visible for selecting vertices during compilation */
 struct Memo
 {
 	int nStates; /* |Phi| */
 	int nChars;  /* |w| */
 	int mode;
 	int encoding;
+	int backrefs; /* Backrefs present? */
 
 	/* Carries structures for use under the various supported encodings.
      * I suppose this could be a union ;-) */
 
 	/* ENCODING_NONE */
-	int **visitVectors; /* Booleans */
+	int **visitVectors; /* Booleans: vv[q][i] */
 
 	/* ENCODING_NEGATIVE */
-	SearchStateTable *searchStateTable; /* < q, i > */
+	SearchStateTable *searchStateTable; /* < q, i [, backrefs ] > */
 
 	/* ENCODING_RLE, ENCODING_RLE_TUNED */
 	RLEVector **rleVectors;

--- a/src-simple/sub.c
+++ b/src-simple/sub.c
@@ -7,7 +7,7 @@
 Sub *freesub;
 
 Sub*
-newsub(int n)
+newsub(int n, char *start)
 {
 	Sub *s;
 	
@@ -17,6 +17,7 @@ newsub(int n)
 	else
 		s = mal(sizeof *s);
 	s->nsub = n;
+	s->start = start;
 	s->ref = 1;
 	return s;
 }
@@ -35,7 +36,8 @@ update(Sub *s, int i, char *p)
 	int j;
 
 	if(s->ref > 1) {
-		s1 = newsub(s->nsub);
+		/* Fork */
+		s1 = newsub(s->nsub, s->start);
 		for(j=0; j<s->nsub; j++)
 			s1->sub[j] = s->sub[j];
 		s->ref--;
@@ -52,4 +54,11 @@ decref(Sub *s)
 		s->sub[0] = (char*)freesub;
 		freesub = s;
 	}
+}
+
+int
+isgroupset(Sub *s, int g)
+{
+	assert(g*2 <= MAXSUB);
+	return s->sub[2*g] != nil && s->sub[2*g + 1] != nil;
 }


### PR DESCRIPTION
Only works with negative encoding (hash table). Hashing is an easy way to fill holes in a vast space in C. The allocation for a memo table would have been ghastly.